### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 
-# liftoff [![Build Status](https://secure.travis-ci.org/tkellen/node-liftoff.png)](http://travis-ci.org/tkellen/node-liftoff) [![Build status](https://ci.appveyor.com/api/projects/status/5a6w8xuq8ed1ilc4/branch/master?svg=true)](https://ci.appveyor.com/project/tkellen/node-liftoff/branch/master)
+# liftoff [![Build Status](https://secure.travis-ci.org/tkellen/js-liftoff.png)](http://travis-ci.org/tkellen/js-liftoff) [![Build status](https://ci.appveyor.com/api/projects/status/5a6w8xuq8ed1ilc4/branch/master?svg=true)](https://ci.appveyor.com/project/tkellen/node-liftoff/branch/master)
 
 > Launch your command line tool with ease.
 


### PR DESCRIPTION
Looks like the AppVeyor is still somehow working off of the old project-name, but travis-ci isn't (which this fix should help with)