### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,7 @@
   "bugs": {
     "url": "https://github.com/tkellen/node-liftoff/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/tkellen/node-liftoff/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "main": "index.js",
   "engines": {
     "node": ">= 0.8"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/